### PR TITLE
Migrate config to `.lua`

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -15,6 +15,7 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 mlua = { version = "0.9.7", features = ["lua54", "vendored", "serialize"] }
 
 [dev-dependencies]
+regex = "1.10.6"
 insta = { version = "1.36.1" }
 tempfile = "3.10.1"
 test_utils = { path = "../test_utils" }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -10,12 +10,11 @@ latest_bin = { path = "../latest_bin" }
 schemars = "0.8.21"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.122"
-serde_yml = "0.0.11"
-toml = "0.8.12"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+mlua = { version = "0.9.7", features = ["lua54", "vendored", "serialize"] }
 
 [dev-dependencies]
-insta = { version = "1.36.1", features = ["yaml", "toml"] }
+insta = { version = "1.36.1" }
 tempfile = "3.10.1"
 test_utils = { path = "../test_utils" }

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -41,7 +41,7 @@ pub fn setup_test_environment() -> TestEnvironment {
 
     TestEnvironment {
         home: temp_home,
-        config_file: config_dir.join("config.yaml"),
+        config_file: config_dir.join("config.lua"),
         config_dir,
         original_home,
     }


### PR DESCRIPTION
```lua
return {
  shell_caching = {
    source = "~/src/rwjblue/dotfiles/zsh/",
    destination = "~/src/rwjblue/dotfiles/zsh/dist/"
  },
  tmux = {
    sessions = {
      {
        name = "✅ todos",
        windows = {
          {
            name = "todos"
          }
        }
      },
      {
        name = "dotfiles",
        windows = {
          {
            name = "dotvim",
            path = "~/src/rwjblue/dotvim",
            command = "nvim"
          },
          {
            name = "dotfiles",
            path = "~/src/rwjblue/dotfiles",
            command = "nvim"
          },
          {
            name = "shared_binutils",
            path = "~/src/malleatus/shared_binutils",
            command = "nvim"
          }
        }
      }
    }
  }
}

```
