### PR TITLE
Add config file path to lua's `package.path`

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -19,3 +19,4 @@ regex = "1.10.6"
 insta = { version = "1.36.1" }
 tempfile = "3.10.1"
 test_utils = { path = "../test_utils" }
+fixturify = { path = "../fixturify" }


### PR DESCRIPTION
Allows doing things like this in your `local.config.lua`:

```lua
local config = require("./config");


local additional_sessions = {
  {
    name = "some-thing-else",
    windows = {
      {
        name = "project-name-here",
      },
    }
  },
};

for _, session in ipairs(additional_sessions) do
  table.insert(config.tmux.sessions, session)
end

return config;
```

