### PR TITLE
feat: extract most globals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["config", "fixturify", "internal-bins", "latest_bin", "test_utils"]
+members = ["config", "fixturify", "internal-bins", "latest_bin", "test_utils", "global"]
 
 [profile.dev.package]
 insta.opt-level = 3

--- a/global/Cargo.toml
+++ b/global/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "global"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["David J. Hamilton <david@hamilton.gg>"]
+
+[dependencies]
+anyhow = "1.0.79"
+clap = { version = "4.5.3", features = ["derive"] }
+cargo_metadata = "0.18.1"
+toml = "0.8.12"
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+walkdir = "2.5.0"
+config = { git = "https://github.com/malleatus/shared_binutils.git" }
+latest_bin = { git = "https://github.com/malleatus/shared_binutils.git" }
+regex = "1.10.6"
+shellexpand = "3.1.0"
+
+[dev-dependencies]
+insta = { version = "1.36.1", features = ["yaml", "toml"] }
+tempfile = "3.10.1"
+temp-env = "0.3.6"
+rand = "0.8.5"
+test_utils = { git = "https://github.com/malleatus/shared_binutils.git" }
+fixturify = { git = "https://github.com/malleatus/shared_binutils.git" }

--- a/global/src/bin/cache-shell-startup.rs
+++ b/global/src/bin/cache-shell-startup.rs
@@ -1,0 +1,456 @@
+use anyhow::{Context, Result};
+use clap::{Parser, ValueEnum};
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tracing::{debug, error, info, trace};
+use tracing_subscriber::EnvFilter;
+
+fn process_file<S: AsRef<Path>>(source_file: S, dest_file: S) -> Result<()> {
+    let source_file = source_file.as_ref();
+    let dest_file = dest_file.as_ref();
+
+    debug!("Processing file: {}", source_file.display());
+
+    let file = File::open(source_file).context("Failed to open file for reading")?;
+    let reader = BufReader::new(file);
+
+    let mut new_content = Vec::new();
+
+    for line in reader.lines() {
+        let line = line.context("Failed to read line")?;
+
+        if let Some(command) = line.strip_prefix("# CMD:") {
+            let trimmed_command = command.trim();
+
+            new_content.push(format!("# CMD: {}", trimmed_command));
+
+            trace!("Running command: {}", trimmed_command);
+
+            let output = Command::new("sh")
+                .arg("-c")
+                .arg(trimmed_command)
+                .output()
+                .context("Failed to execute command")?;
+
+            if output.status.success() {
+                let output_str = String::from_utf8_lossy(&output.stdout);
+                new_content.push(format!(
+                    "# OUTPUT START: {}\n{}\n# OUTPUT END: {}",
+                    trimmed_command, output_str, trimmed_command
+                ));
+            } else {
+                error!(
+                    "Failed to run command '{}':\n {}",
+                    trimmed_command,
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+        } else {
+            new_content.push(line);
+        }
+    }
+
+    if let Some(parent) = dest_file.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create directories for path: {:?}", parent))?;
+    }
+
+    debug!("Writing to file: {}", dest_file.display());
+    trace!("New content:\n{}", new_content.join("\n"));
+
+    let mut output_file = File::create(dest_file)
+        .with_context(|| format!("Failed to open file for writing: {}", dest_file.display()))?;
+
+    for line in new_content {
+        writeln!(output_file, "{}", line).context("Failed to write line")?;
+    }
+
+    output_file.flush().context("Failed to flush file")?;
+
+    Ok(())
+}
+
+fn process_directory(source_dir: &Path, dest_dir: &Path) -> Result<()> {
+    info!("Scanning directory: {}", source_dir.display());
+
+    for entry in fs::read_dir(source_dir)
+        .with_context(|| format!("Failed to read directory: {}", source_dir.display()))?
+    {
+        let entry = entry.context("Failed to process directory entry")?;
+        let path = entry.path();
+
+        if path.starts_with(dest_dir) {
+            continue;
+        }
+
+        if path.is_dir() {
+            let relative_path = path
+                .strip_prefix(source_dir)
+                .context("Failed to get relative path")?;
+            let new_dest_dir = dest_dir.join(relative_path);
+
+            fs::create_dir_all(&new_dest_dir).context("Failed to create destination directory")?;
+            process_directory(&path, &new_dest_dir)
+                .context(format!("Failed to process directory {:?}", path))?;
+        } else {
+            let relative_path = path
+                .strip_prefix(source_dir)
+                .context("Failed to get relative path")?;
+            let dest_file = dest_dir.join(relative_path);
+            process_file(&path, &dest_file)
+                .context(format!("Failed to process file {:?}", path))?;
+        }
+    }
+    Ok(())
+}
+
+/// Represents whether to clear the destination directory
+#[derive(ValueEnum, Clone, Debug, PartialEq)]
+enum DestinationStrategy {
+    Clear,
+    Merge,
+}
+
+/// cache-shell-setup
+///
+/// Processes .zsh files to cache environment variables by running commands
+/// and saving their output. This tool speeds up your shell startup time by
+/// precomputing and caching the output of commands like `brew shellenv`.
+/// It processes all `.zsh` files in a specified directory, looks for specific
+/// commands (e.g., `# CMD:`), executes them, and stores their output directly
+/// in the `.zsh` files, ensuring the operation is idempotent.
+#[derive(Parser, Debug)]
+#[command(name = "cache-shell-setup")]
+struct Args {
+    /// Path to the configuration file. Defaults to `~/.config/binutils/config.yaml`.
+    #[arg(long)]
+    config_file: Option<String>,
+
+    /// Directory path to process
+    #[clap(short, long)]
+    source: Option<String>,
+
+    /// Directory path to emit the expanded output into
+    #[clap(short, long)]
+    destination: Option<String>,
+
+    /// Whether to clear the destination directory before processing
+    #[clap(value_enum, long, default_value_t = DestinationStrategy::Clear)]
+    destination_strategy: DestinationStrategy,
+}
+
+fn run(args: Vec<String>) -> Result<()> {
+    let args = Args::parse_from(args);
+    let config_file = args.config_file.as_ref().map(PathBuf::from);
+    let config = config::read_config(config_file)?;
+
+    let source_dir = if let Some(source) = args.source {
+        source
+    } else if let Some(shell_caching) = &config.shell_caching {
+        shell_caching.source.clone()
+    } else {
+        anyhow::bail!("No source directory provided. Either use the --source flag or set it in the config file. \nArgs: {:?} \nConfig: {:?}", args, config);
+    };
+
+    let destination_dir = if let Some(destination) = args.destination {
+        destination
+    } else if let Some(shell_caching) = &config.shell_caching {
+        shell_caching.destination.clone()
+    } else {
+        anyhow::bail!("No source directory provided. Either use the --source flag or set it in the config file");
+    };
+
+    let source_dir = shellexpand::tilde(&source_dir).to_string();
+    let source_dir = Path::new(&source_dir);
+
+    let dest_dir = shellexpand::tilde(&destination_dir).to_string();
+    let dest_dir = Path::new(&dest_dir);
+
+    if args.destination_strategy == DestinationStrategy::Clear {
+        info!("Clearing destination directory");
+        fs::remove_dir_all(dest_dir).context("Failed to clear destination directory")?;
+    }
+
+    process_directory(source_dir, dest_dir).context("Failed to process directory")
+}
+
+fn main() -> Result<()> {
+    // Initialize tracing, use `info` by default
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    latest_bin::ensure_latest_bin()?;
+
+    let args: Vec<String> = std::env::args().collect();
+    run(args)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use insta::{assert_debug_snapshot, assert_snapshot};
+    use std::collections::BTreeMap;
+    use std::fs::write;
+    use tempfile::tempdir;
+    use test_utils::setup_test_environment;
+
+    #[test]
+    fn test_process_file_with_valid_command() -> Result<()> {
+        let dir = tempdir()?;
+        let source_file = dir.path().join("test.zsh");
+        let dest_file = dir.path().join("output.zsh");
+
+        let content = "# CMD: echo 'hello world'\n";
+        write(&source_file, content)?;
+
+        process_file(&source_file, &dest_file)?;
+
+        let source_contents = fs::read_to_string(&source_file)?;
+
+        assert_snapshot!(source_contents, @r###"
+        # CMD: echo 'hello world'
+        "###);
+
+        let processed_content = fs::read_to_string(&dest_file)?;
+        assert_snapshot!(processed_content, @r###"
+        # CMD: echo 'hello world'
+        # OUTPUT START: echo 'hello world'
+        hello world
+
+        # OUTPUT END: echo 'hello world'
+        "###);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_process_file_with_existing_output() -> Result<()> {
+        let dir = tempdir()?;
+        let source_file = dir.path().join("test.zsh");
+        let dest_file = dir.path().join("output.zsh");
+
+        write(&source_file, "# CMD: echo 'hello world'\n")?;
+        write(&dest_file, "# CMD: echo 'hello world'\n# OUTPUT START: echo 'hello world'\nold output\n# OUTPUT END: echo 'hello world'\n")?;
+
+        process_file(&source_file, &dest_file)?;
+
+        let source_contents = fs::read_to_string(&source_file)?;
+
+        assert_snapshot!(source_contents, @r###"
+        # CMD: echo 'hello world'
+        "###);
+
+        let processed_content = fs::read_to_string(&dest_file)?;
+        assert_snapshot!(processed_content, @r###"
+        # CMD: echo 'hello world'
+        # OUTPUT START: echo 'hello world'
+        hello world
+
+        # OUTPUT END: echo 'hello world'
+        "###);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_process_file_with_invalid_command() -> Result<()> {
+        let dir = tempdir()?;
+        let source_file = dir.path().join("test.zsh");
+        let dest_file = dir.path().join("output.zsh");
+
+        let content = "# CMD: invalidcommand\n";
+        write(&source_file, content)?;
+
+        // Process the file (should not panic, just print error)
+        process_file(&source_file, &dest_file)?;
+
+        let source_contents = fs::read_to_string(&source_file)?;
+
+        assert_snapshot!(source_contents, @r###"
+        # CMD: invalidcommand
+        "###);
+
+        let processed_content = fs::read_to_string(&dest_file)?;
+
+        assert_snapshot!(processed_content, @r###"
+        # CMD: invalidcommand
+        "###);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_process_directory() {
+        let temp_dir = tempdir().unwrap();
+        let base_dir = temp_dir.path();
+
+        let source_files: BTreeMap<String, String> = BTreeMap::from([
+            (
+                "zsh/zshrc".to_string(),
+                "# CMD: echo 'hello world'\n".to_string(),
+            ),
+            (
+                "zsh/plugins/thing.zsh".to_string(),
+                "# CMD: echo 'goodbye world'\n".to_string(),
+            ),
+        ]);
+
+        fixturify::write(base_dir, source_files).unwrap();
+
+        let source_dir = base_dir.join("zsh");
+        let dest_dir = base_dir.join("zsh/dist");
+
+        process_directory(&source_dir, &dest_dir).unwrap();
+
+        let file_map = fixturify::read(base_dir).unwrap();
+
+        assert_debug_snapshot!(file_map, @r###"
+        {
+            "zsh/dist/plugins/thing.zsh": "# CMD: echo 'goodbye world'\n# OUTPUT START: echo 'goodbye world'\ngoodbye world\n\n# OUTPUT END: echo 'goodbye world'\n",
+            "zsh/dist/zshrc": "# CMD: echo 'hello world'\n# OUTPUT START: echo 'hello world'\nhello world\n\n# OUTPUT END: echo 'hello world'\n",
+            "zsh/plugins/thing.zsh": "# CMD: echo 'goodbye world'\n",
+            "zsh/zshrc": "# CMD: echo 'hello world'\n",
+        }
+        "###)
+    }
+
+    #[test]
+    fn test_run_with_args() {
+        let env = setup_test_environment();
+
+        let source_files: BTreeMap<String, String> = BTreeMap::from([
+            (
+                "src/rwjblue/dotfiles/zsh/zshrc".to_string(),
+                "# CMD: echo 'hello world'\n".to_string(),
+            ),
+            (
+                "src/rwjblue/dotfiles/zsh/plugins/thing.zsh".to_string(),
+                "# CMD: echo 'goodbye world'\n".to_string(),
+            ),
+            (
+                "src/rwjblue/dotfiles/zsh/dist/plugins/thing.zsh".to_string(),
+                "# CMD: echo 'goodbye world'\n# OLD OUTPUT SHOULD BE DELETED".to_string(),
+            ),
+        ]);
+
+        fixturify::write(&env.home, source_files).unwrap();
+
+        run(vec![
+            "cache-shell-setup".to_string(),
+            "--source=~/src/rwjblue/dotfiles/zsh".to_string(),
+            "--destination=~/src/rwjblue/dotfiles/zsh/dist".to_string(),
+        ])
+        .unwrap();
+
+        let file_map = fixturify::read(&env.home).unwrap();
+
+        assert_debug_snapshot!(file_map, @r###"
+        {
+            "src/rwjblue/dotfiles/zsh/dist/plugins/thing.zsh": "# CMD: echo 'goodbye world'\n# OUTPUT START: echo 'goodbye world'\ngoodbye world\n\n# OUTPUT END: echo 'goodbye world'\n",
+            "src/rwjblue/dotfiles/zsh/dist/zshrc": "# CMD: echo 'hello world'\n# OUTPUT START: echo 'hello world'\nhello world\n\n# OUTPUT END: echo 'hello world'\n",
+            "src/rwjblue/dotfiles/zsh/plugins/thing.zsh": "# CMD: echo 'goodbye world'\n",
+            "src/rwjblue/dotfiles/zsh/zshrc": "# CMD: echo 'hello world'\n",
+        }
+        "###)
+    }
+
+    #[test]
+    fn test_run_with_config() {
+        let env = setup_test_environment();
+
+        let config_path = &env.config_file;
+        fs::write(
+            config_path,
+            r###"return { shell_caching = { source = "~/other-path/zsh", destination = "~/other-path/zsh/dist" } }"###,
+        )
+        .expect("Could not write to config file");
+
+        let source_files: BTreeMap<String, String> = BTreeMap::from([
+            (
+                "other-path/zsh/zshrc".to_string(),
+                "# CMD: echo 'hello world'\n".to_string(),
+            ),
+            (
+                "other-path/zsh/plugins/thing.zsh".to_string(),
+                "# CMD: echo 'goodbye world'\n".to_string(),
+            ),
+            (
+                "other-path/zsh/dist/plugins/thing.zsh".to_string(),
+                "# CMD: echo 'goodbye world'\n# OLD OUTPUT SHOULD BE DELETED".to_string(),
+            ),
+        ]);
+
+        fixturify::write(&env.home, source_files).unwrap();
+
+        run(vec![]).unwrap();
+
+        let file_map = fixturify::read(&env.home).unwrap();
+
+        assert_debug_snapshot!(file_map, @r###"
+        {
+            ".config/binutils/config.lua": "return { shell_caching = { source = \"~/other-path/zsh\", destination = \"~/other-path/zsh/dist\" } }",
+            "other-path/zsh/dist/plugins/thing.zsh": "# CMD: echo 'goodbye world'\n# OUTPUT START: echo 'goodbye world'\ngoodbye world\n\n# OUTPUT END: echo 'goodbye world'\n",
+            "other-path/zsh/dist/zshrc": "# CMD: echo 'hello world'\n# OUTPUT START: echo 'hello world'\nhello world\n\n# OUTPUT END: echo 'hello world'\n",
+            "other-path/zsh/plugins/thing.zsh": "# CMD: echo 'goodbye world'\n",
+            "other-path/zsh/zshrc": "# CMD: echo 'hello world'\n",
+        }
+        "###)
+    }
+
+    #[test]
+    fn test_run_with_merging() {
+        let env = setup_test_environment();
+
+        let source_files: BTreeMap<String, String> = BTreeMap::from([
+            (
+                "src/rwjblue/dotfiles/zsh/zshrc".to_string(),
+                "# CMD: echo 'hello world'\n".to_string(),
+            ),
+            (
+                "src/rwjblue/dotfiles/zsh/plugins/thing.zsh".to_string(),
+                "# CMD: echo 'goodbye world'\n".to_string(),
+            ),
+            (
+                "src/rwjblue/dotfiles/zsh/dist/plugins/thing.zsh".to_string(),
+                "# CMD: echo 'goodbye world'\n# OLD OUTPUT SHOULD BE DELETED".to_string(),
+            ),
+            (
+                "src/rwjblue/dotfiles/zsh/dist/plugins/weird-other-thing.zsh".to_string(),
+                "# HAHAHA WTF IS THIS?!?! DO NOT WORRY ABOUT".to_string(),
+            ),
+        ]);
+
+        fixturify::write(&env.home, source_files).unwrap();
+
+        run(vec![
+            "cache-shell-setup".to_string(),
+            "--source=~/src/rwjblue/dotfiles/zsh".to_string(),
+            "--destination=~/src/rwjblue/dotfiles/zsh/dist".to_string(),
+            "--destination-strategy=merge".into(),
+        ])
+        .unwrap();
+
+        let file_map = fixturify::read(&env.home).unwrap();
+
+        assert_debug_snapshot!(file_map, @r###"
+        {
+            "src/rwjblue/dotfiles/zsh/dist/plugins/thing.zsh": "# CMD: echo 'goodbye world'\n# OUTPUT START: echo 'goodbye world'\ngoodbye world\n\n# OUTPUT END: echo 'goodbye world'\n",
+            "src/rwjblue/dotfiles/zsh/dist/plugins/weird-other-thing.zsh": "# HAHAHA WTF IS THIS?!?! DO NOT WORRY ABOUT",
+            "src/rwjblue/dotfiles/zsh/dist/zshrc": "# CMD: echo 'hello world'\n# OUTPUT START: echo 'hello world'\nhello world\n\n# OUTPUT END: echo 'hello world'\n",
+            "src/rwjblue/dotfiles/zsh/plugins/thing.zsh": "# CMD: echo 'goodbye world'\n",
+            "src/rwjblue/dotfiles/zsh/zshrc": "# CMD: echo 'hello world'\n",
+        }
+        "###)
+    }
+}
+
+// TODO: Add support to handle race conditions: currently sheldon source reads the files in
+// zsh/dist *but* we also have `# CMD: sheldon source` (which reads those files)
+// Try adding "passes" so you can `# CMD(1): sheldon source` (where the default is "pass 0")
+// and each pass would get flushed to disk together -- this does make a z-index war kinda thing
+// but in practice who cares?

--- a/global/src/bin/generate-binutils-symlinks.rs
+++ b/global/src/bin/generate-binutils-symlinks.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+use tracing::debug;
+use tracing_subscriber::EnvFilter;
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    latest_bin::ensure_latest_bin()?;
+
+    let crate_root = latest_bin::get_crate_root()?;
+    debug!("crate_root: {}", crate_root.display());
+    global::build_utils::generate_symlinks(Some(crate_root))?;
+
+    Ok(())
+}

--- a/global/src/bin/startup-tmux.rs
+++ b/global/src/bin/startup-tmux.rs
@@ -1,0 +1,79 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Parser;
+use config::read_config;
+use global::tmux::{startup_tmux, TmuxOptions};
+use tracing_subscriber::EnvFilter;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct CliTmuxOptions {
+    /// Enable dry run mode. No commands will be executed.
+    #[arg(long)]
+    dry_run: bool,
+
+    /// Enable debug mode. Provides additional output for debugging.
+    #[arg(long)]
+    debug: bool,
+
+    /// Attach to the tmux session after starting it. Defaults to attaching if not within a
+    /// TMUX session already.
+    #[arg(long)]
+    attach: Option<bool>,
+
+    /// Specify the tmux socket name. Defaults to the main tmux socket.
+    #[arg(long)]
+    socket_name: Option<String>,
+
+    /// Path to the configuration file. Defaults to `~/.config/binutils/config.yaml`.
+    #[arg(long)]
+    config_file: Option<String>,
+}
+
+impl TmuxOptions for CliTmuxOptions {
+    fn is_dry_run(&self) -> bool {
+        self.dry_run
+    }
+
+    fn is_debug(&self) -> bool {
+        self.debug
+    }
+
+    fn should_attach(&self) -> Option<bool> {
+        self.attach
+    }
+
+    fn socket_name(&self) -> Option<String> {
+        self.socket_name.clone()
+    }
+
+    fn config_file(&self) -> Option<PathBuf> {
+        self.config_file.as_ref().map(PathBuf::from)
+    }
+}
+
+fn main() -> Result<()> {
+    // Initialize tracing, but only if RUST_LOG is set
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("off")),
+        )
+        .init();
+
+    latest_bin::ensure_latest_bin()?;
+
+    let options = CliTmuxOptions::parse();
+    let config = read_config(options.config_file())?;
+
+    let commands = startup_tmux(&config, &options)?;
+
+    if options.dry_run {
+        println!("Would run the following commands:");
+        for command in commands {
+            println!("\t{}", command);
+        }
+    }
+
+    Ok(())
+}

--- a/global/src/build_utils.rs
+++ b/global/src/build_utils.rs
@@ -149,10 +149,24 @@ mod tests {
         );
 
         let stdout = String::from_utf8_lossy(&output.stdout);
+
+        #[cfg(target_os = "macos")]
         assert_eq!(
             stdout.trim(),
             format!("\"{}\"", bin_path.to_string_lossy().trim()),
             "stdout does not match expected output"
         );
+
+        #[cfg(target_os = "linux")]
+        {
+            let workspace_target_dir = temp_dir.path().join("target").join(profile);
+            let expected_current_exe = workspace_target_dir.join("hello_world");
+
+            assert_eq!(
+                stdout.trim(),
+                format!("\"{}\"", expected_current_exe.to_string_lossy().trim()),
+                "stdout does not match expected output on Linux"
+            );
+        }
     }
 }

--- a/global/src/build_utils.rs
+++ b/global/src/build_utils.rs
@@ -1,0 +1,158 @@
+use anyhow::{Context, Result};
+use cargo_metadata::{MetadataCommand, Package};
+
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
+use tracing::{debug, info};
+
+fn process_package(package: &Package, profile: &str, workspace_target_dir: &Path) -> Result<()> {
+    info!(
+        "Processing {} from {}",
+        &package.name, &package.manifest_path
+    );
+
+    let crate_root = PathBuf::from(&package.manifest_path)
+        .parent()
+        .unwrap()
+        .to_path_buf();
+
+    let crate_target_dir = crate_root.join("target").join(profile);
+
+    // TODO: add option (threaded through the bin) to opt-out of clearing
+    if crate_target_dir.exists() {
+        info!(
+            "{}/target already exists, removing it",
+            &crate_target_dir.display()
+        );
+
+        fs::remove_dir_all(&crate_target_dir).with_context(|| {
+            format!(
+                "Failed to remove existing crate target directory: {}",
+                crate_target_dir.display()
+            )
+        })?;
+    }
+
+    fs::create_dir_all(&crate_target_dir).with_context(|| {
+        format!(
+            "Failed to create crate target directory: {}",
+            crate_target_dir.display()
+        )
+    })?;
+
+    for target in package.targets.iter() {
+        if target.kind.contains(&"bin".to_string()) {
+            let source_path = workspace_target_dir.join(&target.name);
+            let dest_path = crate_target_dir.join(&target.name);
+
+            info!("\tProcessing binary {}", target.name,);
+
+            debug!(
+                "\t\tLinking from {} -> {}",
+                source_path.display(),
+                dest_path.display()
+            );
+
+            if !dest_path.exists() {
+                symlink(&source_path, &dest_path).context("Failed to create symlink")?;
+            } else {
+                debug!("\t\tSymlink already exists: {}", dest_path.display());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn generate_symlinks(working_dir: Option<PathBuf>) -> Result<()> {
+    info!("Generating crate local target symlinks for local workspace packages");
+    let working_dir = working_dir.unwrap_or(PathBuf::from("."));
+
+    // TODO: automatically support both debug and release profiles
+    let profile = "debug";
+
+    let metadata = MetadataCommand::new()
+        .current_dir(working_dir)
+        .exec()
+        .expect("Failed to load metadata");
+
+    let workspace_root = PathBuf::from(&metadata.workspace_root);
+
+    let workspace_target_dir = workspace_root.join("target").join(profile);
+
+    for package in metadata.workspace_packages() {
+        process_package(package, profile, &workspace_target_dir)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+    use test_utils::{create_workspace_with_packages, FakeBin, FakePackage};
+
+    #[test]
+    fn test_process_package_target_exists() {
+        let temp_dir = tempdir().unwrap();
+        let packages = vec![FakePackage {
+            name: "test_package".to_string(),
+            bins: vec![FakeBin {
+                name: "hello_world".to_string(),
+                contents: None,
+            }],
+        }];
+        create_workspace_with_packages(temp_dir.path(), packages);
+
+        let profile = "debug";
+
+        let package_dir = temp_dir.path().join("test_package");
+        let crate_target_dir = package_dir.join("target").join(profile);
+
+        generate_symlinks(Some(temp_dir.path().to_path_buf())).unwrap();
+
+        assert!(crate_target_dir.join("hello_world").exists());
+    }
+
+    #[test]
+    fn test_test_package_bin_is_executable() {
+        let temp_dir = tempdir().unwrap();
+        let packages = vec![FakePackage {
+            name: "test_package".to_string(),
+            bins: vec![FakeBin {
+                name: "hello_world".to_string(),
+                contents: None,
+            }],
+        }];
+        create_workspace_with_packages(temp_dir.path(), packages);
+
+        let profile = "debug";
+
+        let package_dir = temp_dir.path().join("test_package");
+        let crate_target_dir = package_dir.join("target").join(profile);
+
+        generate_symlinks(Some(temp_dir.path().to_path_buf())).unwrap();
+
+        let bin_path = crate_target_dir.join("hello_world");
+        assert!(bin_path.exists(), "precond - file exists");
+
+        let output = std::process::Command::new(bin_path.clone())
+            .output()
+            .expect("failed to execute process");
+
+        assert!(
+            output.status.success(),
+            "process did not exit successfully: {}",
+            output.status
+        );
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert_eq!(
+            stdout.trim(),
+            format!("\"{}\"", bin_path.to_string_lossy().trim()),
+            "stdout does not match expected output"
+        );
+    }
+}

--- a/global/src/lib.rs
+++ b/global/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod build_utils;
+pub mod tmux;

--- a/global/src/tmux.rs
+++ b/global/src/tmux.rs
@@ -1,0 +1,1150 @@
+use anyhow::Result;
+use std::os::unix::process::CommandExt;
+use std::{collections::BTreeMap, path::PathBuf, process::Command};
+use tracing::{debug, trace};
+
+use config::{Command as ConfigCommand, Config, Window};
+
+/// `TmuxOptions` is a trait for managing various options for working with these tmux utilities.
+///
+/// It provides methods to check if the current run is a dry run, if it's in debug mode, and if it should attach to tmux.
+pub trait TmuxOptions {
+    /// Checks if the current run is a dry run.
+    ///
+    /// In a dry run, commands are not actually executed. Instead, they are just printed to the console.
+    /// This is useful for testing and debugging.
+    fn is_dry_run(&self) -> bool;
+
+    /// Checks if the current run is in debug mode.
+    fn is_debug(&self) -> bool;
+
+    /// Provides the socket name of the tmux server to attach to.
+    ///
+    /// If this returns `None`, the default socket name will be used.
+    fn socket_name(&self) -> Option<String>;
+
+    /// Decides if we should attach to tmux in the running terminal.
+    ///
+    /// Returns `Some(true)` if we should attach, `Some(false)` if we should not, and `None` if the decision is left to the default behavior.
+    fn should_attach(&self) -> Option<bool>;
+
+    fn config_file(&self) -> Option<PathBuf>;
+
+    fn _is_testing(&self) -> bool {
+        false
+    }
+}
+
+pub fn in_tmux() -> bool {
+    std::env::var("TMUX").is_ok()
+}
+
+fn get_socket_name(options: &impl TmuxOptions) -> String {
+    options
+        .socket_name()
+        .unwrap_or_else(|| "default".to_string())
+}
+
+pub fn startup_tmux(config: &Config, options: &impl TmuxOptions) -> Result<Vec<String>> {
+    let mut current_state = gather_tmux_state(options);
+    let mut commands = vec![];
+
+    match &config.tmux {
+        Some(tmux) => {
+            for session in &tmux.sessions {
+                for window in &session.windows {
+                    let commands_executed =
+                        ensure_window(&session.name, window, &mut current_state, options)?;
+
+                    for command in commands_executed {
+                        commands.push(generate_debug_string_for_command(&command));
+                    }
+                }
+            }
+
+            if let Some(attach_command) = maybe_attach_tmux(config, options)? {
+                // NOTE: this only runs for `--dry-run` or `--attach=false` cases
+                commands.push(generate_debug_string_for_command(&attach_command));
+            }
+        }
+        None => {
+            debug!("No tmux configuration found, skipping tmux setup");
+        }
+    }
+
+    Ok(commands)
+}
+
+fn maybe_attach_tmux(config: &Config, options: &impl TmuxOptions) -> Result<Option<Command>> {
+    let should_attach = options.should_attach().unwrap_or_else(|| {
+        trace!("`--attach` was not explicitly specified, checking $TMUX");
+
+        !in_tmux()
+    });
+
+    if !should_attach {
+        trace!("Not attaching to tmux session: options.should_attach() returned false");
+        return Ok(None);
+    }
+
+    let mut cmd = Command::new("tmux");
+    cmd.arg("attach");
+    if let Some(tmux) = &config.tmux {
+        if let Some(default_session) = &tmux.default_session {
+            cmd.arg("-t").arg(default_session);
+        }
+    }
+
+    let should_attach = !options.is_dry_run() && !options._is_testing();
+
+    if should_attach {
+        let result = cmd.exec();
+        // SAFETY: We should never actually hit this line, as exec should replace the current process
+        anyhow::bail!("Failed to execute tmux attach command: {:?}", result)
+    } else {
+        trace!(
+            "Not attaching! Dry run: {} -- Testing: {}",
+            options.is_dry_run(),
+            options._is_testing()
+        );
+        Ok(Some(cmd))
+    }
+}
+
+#[allow(dead_code)]
+fn determine_commands_for_window(
+    window: &Window,
+    crates: BTreeMap<String, PathBuf>,
+) -> Result<Option<Vec<String>>> {
+    let mut commands: Vec<String> = if let Some(command) = &window.command {
+        match command {
+            config::Command::Single(cmd) => vec![cmd.clone()],
+            config::Command::Multiple(cmds) => cmds.clone(),
+        }
+    } else if window.linked_crates.is_some() {
+        vec![]
+    } else {
+        // no command, no linked crates; nothing to do
+        return Ok(None);
+    };
+
+    if let Some(linked_crates) = &window.linked_crates {
+        // TODO: find the linked_crates using crate_locations and add them to the PATH
+        for linked_crate in linked_crates {
+            if let Some(crate_path) = crates.get(linked_crate) {
+                let new_command = format!(
+                    "export PATH={}:$PATH",
+                    crate_path.to_str().unwrap_or_default()
+                );
+                commands.push(new_command);
+            } else {
+                anyhow::bail!(
+                    "Could not find crate: {} for linking into {}",
+                    linked_crate,
+                    window.name
+                );
+            }
+        }
+    }
+
+    if commands.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(commands))
+    }
+}
+
+fn ensure_window(
+    session_name: &str,
+    window: &Window,
+    current_state: &mut TmuxState,
+    options: &impl TmuxOptions,
+) -> Result<Vec<Command>> {
+    let socket_name = get_socket_name(options);
+    let mut commands_executed = vec![];
+
+    trace!("Current state: {:#?}", current_state);
+
+    if let Some(windows) = current_state.get_mut(session_name) {
+        if windows.contains(&window.name) {
+            trace!(
+                "Window {} already exists in session {}, skipping creation",
+                window.name,
+                session_name
+            );
+        } else {
+            trace!(
+                "Window {} does not exist in session {}, creating it",
+                window.name,
+                session_name
+            );
+
+            let mut cmd = Command::new("tmux");
+            cmd.arg("-L")
+                .arg(&socket_name)
+                .arg("new-window")
+                .arg("-t")
+                .arg(format!("{}:", session_name))
+                .arg("-n")
+                .arg(&window.name);
+
+            if let Some(path) = &window.path {
+                cmd.arg("-c").arg(path);
+            }
+
+            if let Some(env) = &window.env {
+                for (key, value) in env {
+                    cmd.arg("-e").arg(format!("{}={}", key, value));
+                }
+            }
+
+            commands_executed.push(run_command(cmd, options)?);
+            commands_executed.extend(execute_command(session_name, window, options)?);
+
+            windows.push(window.name.to_string());
+        }
+    } else {
+        trace!(
+            "Session {} does not exist, creating it and window {}",
+            session_name,
+            window.name
+        );
+
+        let mut cmd = Command::new("tmux");
+        cmd.arg("-L")
+            .arg(&socket_name)
+            .arg("new-session")
+            .arg("-d")
+            .arg("-s")
+            .arg(session_name)
+            .arg("-n")
+            .arg(&window.name);
+
+        if let Some(path) = &window.path {
+            cmd.arg("-c").arg(path);
+        }
+
+        if let Some(env) = &window.env {
+            for (key, value) in env {
+                cmd.arg("-e").arg(format!("{}={}", key, value));
+            }
+        }
+
+        // push the session / window creation command
+        commands_executed.push(run_command(cmd, options)?);
+
+        // push any commands referenced in the config for the window
+        commands_executed.extend(execute_command(session_name, window, options)?);
+
+        current_state.insert(session_name.to_string(), vec![window.name.to_string()]);
+    }
+
+    Ok(commands_executed)
+}
+
+fn execute_command(
+    session_name: &str,
+    window: &Window,
+    options: &impl TmuxOptions,
+) -> Result<Vec<Command>> {
+    let mut commands_executed = vec![];
+
+    if let Some(command) = &window.command {
+        match command {
+            ConfigCommand::Single(command) => {
+                let mut cmd = Command::new("tmux");
+                cmd.arg("-L")
+                    .arg(get_socket_name(options))
+                    .arg("send-keys")
+                    .arg("-t")
+                    .arg(format!("{}:{}", session_name, window.name))
+                    .arg(command)
+                    .arg("Enter");
+
+                let cmd = run_command(cmd, options)?;
+                commands_executed.push(cmd);
+            }
+            ConfigCommand::Multiple(commands) => {
+                for command in commands {
+                    let mut cmd = Command::new("tmux");
+                    cmd.arg("-L")
+                        .arg(get_socket_name(options))
+                        .arg("send-keys")
+                        .arg("-t")
+                        .arg(format!("{}:{}", session_name, window.name))
+                        .arg(command)
+                        .arg("Enter");
+
+                    let cmd = run_command(cmd, options)?;
+                    commands_executed.push(cmd);
+                }
+            }
+        }
+    }
+
+    Ok(commands_executed)
+}
+
+type TmuxState = BTreeMap<String, Vec<String>>;
+
+/// Runs `tmux list-sessions -F #{session_name}` to gather sessions, then for each session
+/// runs `tmux list-windows -F #{window_name}` and returns a HashMap where the keys are session
+/// names and the values is an array of the window names.
+fn gather_tmux_state(options: &impl TmuxOptions) -> TmuxState {
+    let mut state = BTreeMap::new();
+
+    let socket_name = get_socket_name(options);
+
+    let sessions_output = Command::new("tmux")
+        .arg("-L")
+        .arg(&socket_name)
+        .arg("list-sessions")
+        .arg("-F")
+        .arg("#{session_name}")
+        .output()
+        .expect("Failed to execute command");
+
+    let sessions = String::from_utf8(sessions_output.stdout).unwrap();
+    for session in sessions.lines() {
+        let windows_output = Command::new("tmux")
+            .arg("-L")
+            .arg(&socket_name)
+            .arg("list-windows")
+            .arg("-F")
+            .arg("#{window_name}")
+            .arg("-t")
+            .arg(session)
+            .output()
+            .expect("Failed to execute command");
+
+        let windows = String::from_utf8(windows_output.stdout).unwrap();
+        state.insert(
+            session.to_string(),
+            windows
+                .lines()
+                .map(|s| s.to_string())
+                .collect::<Vec<String>>(),
+        );
+    }
+
+    state
+}
+
+fn run_command(mut cmd: Command, opts: &impl TmuxOptions) -> Result<Command> {
+    trace!("Running: {}", generate_debug_string_for_command(&cmd));
+
+    if !opts.is_dry_run() {
+        cmd.output()?;
+    }
+
+    Ok(cmd)
+}
+
+/// Generates a debug string representation of a `Command`.
+fn generate_debug_string_for_command(cmd: &Command) -> String {
+    let mut cmd_string = String::new();
+
+    if let Some(program) = cmd.get_program().to_str() {
+        cmd_string.push_str(program);
+    }
+
+    for arg in cmd.get_args() {
+        if let Some(arg_str) = arg.to_str() {
+            cmd_string.push(' ');
+
+            if arg_str.contains(' ') || arg_str.contains('"') {
+                cmd_string.push('\'');
+                for c in arg_str.chars() {
+                    if c == '\'' {
+                        cmd_string.push('\\');
+                    }
+                    cmd_string.push(c);
+                }
+                cmd_string.push('\'');
+            } else if arg_str.contains('\'') {
+                cmd_string.push('"');
+                for c in arg_str.chars() {
+                    if c == '"' {
+                        cmd_string.push('\\');
+                    }
+                    cmd_string.push(c);
+                }
+                cmd_string.push('"');
+            } else {
+                cmd_string.push_str(arg_str);
+            }
+        }
+    }
+
+    cmd_string
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashMap,
+        env, fs,
+        path::Path,
+        thread::sleep,
+        time::{Duration, Instant},
+    };
+
+    use anyhow::Result;
+    use insta::{assert_debug_snapshot, assert_yaml_snapshot};
+    use rand::{distributions::Alphanumeric, Rng};
+    use tempfile::tempdir;
+    use test_utils::{create_workspace_with_packages, FakeBin, FakePackage};
+
+    use crate::build_utils::generate_symlinks;
+
+    use super::*;
+    use config::{Session, Tmux, Window};
+
+    struct TestingTmuxOptions {
+        dry_run: bool,
+        debug: bool,
+        attach: Option<bool>,
+        socket_name: String,
+        _config_file: Option<PathBuf>,
+    }
+    impl TmuxOptions for TestingTmuxOptions {
+        fn is_dry_run(&self) -> bool {
+            self.dry_run
+        }
+
+        fn is_debug(&self) -> bool {
+            self.debug
+        }
+
+        fn should_attach(&self) -> Option<bool> {
+            self.attach
+        }
+
+        fn socket_name(&self) -> Option<String> {
+            Some(self.socket_name.clone())
+        }
+
+        fn config_file(&self) -> Option<PathBuf> {
+            None
+        }
+
+        fn _is_testing(&self) -> bool {
+            true
+        }
+    }
+
+    impl Drop for TestingTmuxOptions {
+        fn drop(&mut self) {
+            kill_tmux_server(self).unwrap();
+        }
+    }
+
+    fn generate_socket_name() -> String {
+        let rng = rand::thread_rng();
+        let socket_name: String = rng
+            .sample_iter(&Alphanumeric)
+            .take(30)
+            .map(char::from)
+            .collect();
+        socket_name
+    }
+
+    fn create_tmux_session(
+        session_name: &str,
+        window_name: &str,
+        options: &impl TmuxOptions,
+    ) -> Result<(), std::io::Error> {
+        let socket_name = get_socket_name(options);
+
+        // Create the session with the initial window
+        let _ = Command::new("tmux")
+            .arg("-L")
+            .arg(socket_name)
+            .arg("new-session")
+            .arg("-d")
+            .arg("-s")
+            .arg(session_name)
+            .arg("-n")
+            .arg(window_name)
+            .status()?;
+
+        assert!(tmux_server_running(options));
+
+        Ok(())
+    }
+
+    fn kill_tmux_server(options: &impl TmuxOptions) -> Result<()> {
+        let socket_name = get_socket_name(options);
+
+        let _ = Command::new("tmux")
+            .arg("-L")
+            .arg(socket_name)
+            .arg("kill-server")
+            .status()?;
+
+        Ok(())
+    }
+
+    fn tmux_server_running(options: &impl TmuxOptions) -> bool {
+        let socket_name = get_socket_name(options);
+
+        Command::new("tmux")
+            .arg("-L")
+            .arg(socket_name)
+            .arg("has-session")
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    }
+
+    fn build_testing_options() -> TestingTmuxOptions {
+        let options = TestingTmuxOptions {
+            dry_run: false,
+            debug: false,
+            attach: None,
+            socket_name: generate_socket_name(),
+            _config_file: None,
+        };
+
+        assert!(
+            !tmux_server_running(&options),
+            "precond - tmux server should not be running on randomized socket name"
+        );
+
+        options
+    }
+
+    fn sanitize_commands_executed(
+        commands: Vec<String>,
+        options: &TestingTmuxOptions,
+        additional_replacements: Option<HashMap<String, String>>,
+    ) -> Vec<String> {
+        commands
+            .iter()
+            .map(|command| {
+                let mut updated_command = command.replace(&options.socket_name, "[SOCKET_NAME]");
+                if let Some(replacements) = &additional_replacements {
+                    for (key, value) in replacements {
+                        updated_command = updated_command.replace(key, value);
+                    }
+                }
+                updated_command
+            })
+            .collect()
+    }
+
+    fn wait_for_file(path: &Path, message: String) {
+        let start = Instant::now();
+        let timeout = Duration::from_secs(2);
+
+        loop {
+            // Check if the file exists
+            if path.exists() {
+                break;
+            }
+
+            // Sleep for 10ms
+            sleep(Duration::from_millis(10));
+
+            // Check if the elapsed time is greater than the timeout
+            if start.elapsed() > timeout {
+                panic!("{}", message);
+            }
+        }
+    }
+
+    #[test]
+    fn test_in_tmux_within_tmux() {
+        temp_env::with_var(
+            "TMUX",
+            Some("/private/tmp/tmux-23547/default,39774,0"),
+            || {
+                assert!(in_tmux());
+            },
+        );
+    }
+
+    #[test]
+    fn test_in_tmux_outside_tmux() {
+        temp_env::with_var("TMUX", None::<String>, || {
+            assert!(!in_tmux());
+        });
+    }
+
+    #[test]
+    fn test_gather_tmux_state() -> Result<()> {
+        let options = build_testing_options();
+
+        create_tmux_session("foo", "bar", &options)?;
+
+        assert_debug_snapshot!(gather_tmux_state(&options), @r###"
+        {
+            "foo": [
+                "bar",
+            ],
+        }
+        "###);
+
+        create_tmux_session("baz", "qux", &options)?;
+
+        assert_debug_snapshot!(gather_tmux_state(&options), @r###"
+        {
+            "baz": [
+                "qux",
+            ],
+            "foo": [
+                "bar",
+            ],
+        }
+        "###);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_creates_all_windows_when_server_is_not_started() -> Result<()> {
+        let options = build_testing_options();
+        let config = Config {
+            crate_locations: None,
+            shell_caching: None,
+            tmux: Some(Tmux {
+                default_session: None,
+                sessions: vec![Session {
+                    name: "foo".to_string(),
+                    windows: vec![
+                        Window {
+                            name: "bar".to_string(),
+                            path: None,
+                            command: None,
+                            env: None,
+                            linked_crates: None,
+                        },
+                        Window {
+                            name: "baz".to_string(),
+                            path: None,
+                            command: None,
+                            env: None,
+                            linked_crates: None,
+                        },
+                        Window {
+                            name: "qux".to_string(),
+                            path: None,
+                            command: None,
+                            env: None,
+                            linked_crates: None,
+                        },
+                        Window {
+                            name: "derp".to_string(),
+                            path: None,
+                            command: None,
+                            env: None,
+                            linked_crates: None,
+                        },
+                    ],
+                }],
+            }),
+        };
+        let commands = startup_tmux(&config, &options)?;
+        let commands = sanitize_commands_executed(commands, &options, None);
+
+        assert_yaml_snapshot!(commands, @r###"
+        ---
+        - "tmux -L [SOCKET_NAME] new-session -d -s foo -n bar"
+        - "tmux -L [SOCKET_NAME] new-window -t foo: -n baz"
+        - "tmux -L [SOCKET_NAME] new-window -t foo: -n qux"
+        - "tmux -L [SOCKET_NAME] new-window -t foo: -n derp"
+        - "tmux attach -t foo",
+        "###);
+
+        assert_debug_snapshot!(gather_tmux_state(&options), @r###"
+        {
+            "foo": [
+                "bar",
+                "baz",
+                "qux",
+                "derp",
+            ],
+        }
+        "###);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_creates_missing_windows_when_server_is_already_started() -> Result<()> {
+        let options = build_testing_options();
+
+        create_tmux_session("foo", "baz", &options)?;
+
+        let config = Config {
+            crate_locations: None,
+            shell_caching: None,
+            tmux: Some(Tmux {
+                default_session: None,
+                sessions: vec![Session {
+                    name: "foo".to_string(),
+                    windows: vec![
+                        Window {
+                            name: "baz".to_string(),
+                            path: None,
+                            command: None,
+                            env: None,
+                            linked_crates: None,
+                        },
+                        Window {
+                            name: "bar".to_string(),
+                            path: None,
+                            command: None,
+                            env: None,
+                            linked_crates: None,
+                        },
+                    ],
+                }],
+            }),
+        };
+
+        let commands = startup_tmux(&config, &options)?;
+        let commands = sanitize_commands_executed(commands, &options, None);
+
+        assert_yaml_snapshot!(commands, @r###"
+        ---
+        - "tmux -L [SOCKET_NAME] new-window -t foo: -n bar"
+        "###);
+
+        assert_debug_snapshot!(gather_tmux_state(&options), @r###"
+        {
+            "foo": [
+                "baz",
+                "bar",
+            ],
+        }
+        "###);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_does_nothing_if_already_started() -> Result<()> {
+        let options = build_testing_options();
+
+        create_tmux_session("foo", "bar", &options)?;
+
+        assert_debug_snapshot!(gather_tmux_state(&options), @r###"
+        {
+            "foo": [
+                "bar",
+            ],
+        }
+        "###);
+
+        let config = Config {
+            crate_locations: None,
+            shell_caching: None,
+            tmux: Some(Tmux {
+                default_session: None,
+                sessions: vec![Session {
+                    name: "foo".to_string(),
+                    windows: vec![Window {
+                        linked_crates: None,
+                        name: "bar".to_string(),
+                        path: None,
+                        command: None,
+                        env: None,
+                    }],
+                }],
+            }),
+        };
+        let commands = startup_tmux(&config, &options)?;
+        let commands = sanitize_commands_executed(commands, &options, None);
+
+        assert_yaml_snapshot!(commands, @r###"
+        ---
+        []
+        "###);
+
+        assert_debug_snapshot!(gather_tmux_state(&options), @r###"
+        {
+            "foo": [
+                "bar",
+            ],
+        }
+        "###);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_sets_specified_environment_variables_when_window_is_created() -> Result<()> {
+        let options = build_testing_options();
+
+        let temp_dir = tempdir().expect("Failed to create a temporary directory");
+        let temp_path = temp_dir.into_path();
+        let temp_path = temp_path.join("some-file.txt");
+        let temp_path_str = temp_path
+            .to_str()
+            .expect("Failed to convert temp path to str");
+
+        let mut additional_replacements = HashMap::new();
+        additional_replacements.insert(
+            temp_path_str.to_string(),
+            "/tmp/random-value/some-file.txt".to_string(),
+        );
+
+        let config = Config {
+            crate_locations: None,
+            shell_caching: None,
+            tmux: Some(Tmux {
+                default_session: None,
+                sessions: vec![Session {
+                    name: "foo".to_string(),
+                    windows: vec![Window {
+                        linked_crates: None,
+                        name: "bar".to_string(),
+                        path: None,
+                        command: Some(ConfigCommand::Single(format!(
+                            "echo \"$FOO-$BAZ\" > {}",
+                            temp_path_str
+                        ))),
+                        env: Some(BTreeMap::from([
+                            ("FOO".to_string(), "bar".to_string()),
+                            ("BAZ".to_string(), "qux".to_string()),
+                        ])),
+                    }],
+                }],
+            }),
+        };
+
+        let commands = startup_tmux(&config, &options)?;
+
+        let commands =
+            sanitize_commands_executed(commands, &options, Some(additional_replacements));
+        assert_yaml_snapshot!(commands, @r###"
+        ---
+        - "tmux -L [SOCKET_NAME] new-session -d -s foo -n bar -e BAZ=qux -e FOO=bar"
+        - "tmux -L [SOCKET_NAME] send-keys -t foo:bar 'echo \"$FOO-$BAZ\" > /tmp/random-value/some-file.txt' Enter"
+        "###);
+
+        wait_for_file(
+            &temp_path,
+            format!(
+                "tmux socket: {} -- file not created: {}",
+                options.socket_name,
+                temp_path.to_str().unwrap()
+            ),
+        );
+
+        assert_eq!(std::fs::read_to_string(&temp_path)?, "bar-qux\n");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_invokes_command_when_window_is_created() -> Result<()> {
+        let options = build_testing_options();
+
+        let temp_dir = tempdir().expect("Failed to create a temporary directory");
+        let temp_path = temp_dir.into_path();
+        let temp_path = temp_path.join("some-file.txt");
+        let temp_path_str = temp_path
+            .to_str()
+            .expect("Failed to convert temp path to str");
+
+        let mut additional_replacements = HashMap::new();
+        additional_replacements.insert(
+            temp_path_str.to_string(),
+            "/tmp/random-value/some-file.txt".to_string(),
+        );
+
+        let config = Config {
+            crate_locations: None,
+            shell_caching: None,
+            tmux: Some(Tmux {
+                default_session: None,
+                sessions: vec![Session {
+                    name: "foo".to_string(),
+                    windows: vec![Window {
+                        name: "bar".to_string(),
+                        path: None,
+                        command: Some(ConfigCommand::Single(format!("touch {}", temp_path_str))),
+                        env: None,
+                        linked_crates: None,
+                    }],
+                }],
+            }),
+        };
+
+        let commands = startup_tmux(&config, &options)?;
+
+        let commands =
+            sanitize_commands_executed(commands, &options, Some(additional_replacements));
+        assert_yaml_snapshot!(commands, @r###"
+        ---
+        - "tmux -L [SOCKET_NAME] new-session -d -s foo -n bar"
+        - "tmux -L [SOCKET_NAME] send-keys -t foo:bar 'touch /tmp/random-value/some-file.txt' Enter"
+        "###);
+        assert_debug_snapshot!(gather_tmux_state(&options), @r###"
+        {
+            "foo": [
+                "bar",
+            ],
+        }
+        "###);
+
+        wait_for_file(
+            &temp_path,
+            format!(
+                "tmux socket: {} -- file not created: {}",
+                options.socket_name,
+                temp_path.to_str().unwrap()
+            ),
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_attempts_to_attach_to_default_session() -> Result<()> {
+        env::remove_var("TMUX");
+
+        let options = build_testing_options();
+
+        let config = Config {
+            crate_locations: None,
+            shell_caching: None,
+            tmux: Some(Tmux {
+                default_session: Some("foo".to_string()),
+                sessions: vec![Session {
+                    name: "foo".to_string(),
+                    windows: vec![Window {
+                        name: "bar".to_string(),
+                        path: None,
+                        command: None,
+                        env: None,
+                        linked_crates: None,
+                    }],
+                }],
+            }),
+        };
+        let commands = startup_tmux(&config, &options)?;
+        let commands = sanitize_commands_executed(commands, &options, None);
+
+        assert_debug_snapshot!(commands, @r###"
+        [
+            "tmux -L [SOCKET_NAME] new-session -d -s foo -n bar",
+            "tmux attach -t foo",
+        ]
+        "###);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_attempts_to_attach_without_default_session() -> Result<()> {
+        env::remove_var("TMUX");
+
+        let options = build_testing_options();
+
+        let config = Config {
+            crate_locations: None,
+            shell_caching: None,
+            tmux: Some(Tmux {
+                default_session: None,
+                sessions: vec![Session {
+                    name: "foo".to_string(),
+                    windows: vec![Window {
+                        name: "bar".to_string(),
+                        path: None,
+                        command: None,
+                        env: None,
+                        linked_crates: None,
+                    }],
+                }],
+            }),
+        };
+        let commands = startup_tmux(&config, &options)?;
+        let commands = sanitize_commands_executed(commands, &options, None);
+
+        assert_debug_snapshot!(commands, @r###"
+        [
+            "tmux -L [SOCKET_NAME] new-session -d -s foo -n bar",
+            "tmux attach",
+        ]
+        "###);
+
+        Ok(())
+    }
+
+    #[test]
+    fn determine_commands_for_window_single_command() {
+        let window = Window {
+            path: None,
+            env: None,
+            name: "test_window".to_string(),
+            command: Some(config::Command::Single("echo Hello".to_string())),
+            linked_crates: None,
+        };
+        let crates = BTreeMap::new();
+        let result = determine_commands_for_window(&window, crates).unwrap();
+        assert_debug_snapshot!(result, @r###"
+        Some(
+            [
+                "echo Hello",
+            ],
+        )
+        "###);
+    }
+
+    #[test]
+    fn determine_commands_for_window_multiple_commands() {
+        let window = Window {
+            path: None,
+            env: None,
+            name: "test_window".to_string(),
+            command: Some(config::Command::Multiple(vec![
+                "echo Hello".to_string(),
+                "echo World".to_string(),
+            ])),
+            linked_crates: None,
+        };
+        let crates = BTreeMap::new();
+        let result = determine_commands_for_window(&window, crates).unwrap();
+        assert_debug_snapshot!(result, @r###"
+        Some(
+            [
+                "echo Hello",
+                "echo World",
+            ],
+        )
+        "###);
+    }
+
+    #[test]
+    fn determine_commands_for_window_no_command_with_linked_crates() {
+        let window = Window {
+            path: None,
+            env: None,
+            name: "test_window".to_string(),
+            command: None,
+            linked_crates: Some(vec!["crate1".to_string()]),
+        };
+        let mut crates = BTreeMap::new();
+        crates.insert("crate1".to_string(), PathBuf::from("/path/to/crate1"));
+        let result = determine_commands_for_window(&window, crates).unwrap();
+        assert_debug_snapshot!(result, @r###"
+        Some(
+            [
+                "export PATH=/path/to/crate1:$PATH",
+            ],
+        )
+        "###);
+    }
+
+    #[test]
+    fn determine_commands_for_window_no_command_no_linked_crates() {
+        let window = Window {
+            path: None,
+            env: None,
+            name: "test_window".to_string(),
+            command: None,
+            linked_crates: None,
+        };
+        let crates = BTreeMap::new();
+        let result = determine_commands_for_window(&window, crates).unwrap();
+        assert_debug_snapshot!(result, @"None");
+    }
+
+    #[test]
+    fn determine_commands_for_window_missing_crate() {
+        let window = Window {
+            path: None,
+            env: None,
+            name: "test_window".to_string(),
+            command: None,
+            linked_crates: Some(vec!["missing_crate".to_string()]),
+        };
+        let crates = BTreeMap::new();
+        let result = determine_commands_for_window(&window, crates);
+
+        assert_debug_snapshot!(result, @r###"
+        Err(
+            "Could not find crate: missing_crate for linking into test_window",
+        )
+        "###);
+    }
+
+    #[test]
+    fn test_linked_crates() -> Result<()> {
+        let temp_dir = tempdir()?;
+        let options = build_testing_options();
+
+        let workspace_dir = temp_dir.path().join("workspace");
+        create_workspace_with_packages(
+            workspace_dir.as_path(),
+            vec![FakePackage {
+                name: "foo".to_string(),
+                bins: vec![FakeBin {
+                    name: "bar".to_string(),
+                    contents: Some(
+                        r###"
+                        use std::fs::File;
+
+                        fn main() {
+                            File::create("foo.txt").unwrap();
+                        }"###
+                            .to_string(),
+                    ),
+                }],
+            }],
+        );
+
+        generate_symlinks(Some(workspace_dir.clone())).unwrap();
+
+        let working_dir = temp_dir.path().join("working_dir");
+        fs::create_dir_all(&working_dir)?;
+
+        let config = Config {
+            crate_locations: Some(vec![workspace_dir.to_string_lossy().to_string()]),
+            shell_caching: None,
+            tmux: Some(Tmux {
+                default_session: Some("foo".to_string()),
+                sessions: vec![Session {
+                    name: "foo".to_string(),
+                    windows: vec![Window {
+                        name: "bar".to_string(),
+                        path: Some(working_dir.to_path_buf()),
+                        command: Some(ConfigCommand::Single("bar".to_string())),
+                        env: None,
+                        linked_crates: Some(vec!["foo".to_string()]),
+                    }],
+                }],
+            }),
+        };
+        let commands = startup_tmux(&config, &options)?;
+        let commands = sanitize_commands_executed(
+            commands,
+            &options,
+            Some(HashMap::from([(
+                temp_dir.path().to_string_lossy().to_string(),
+                "[TEMP_DIR]".to_string(),
+            )])),
+        );
+
+        assert_debug_snapshot!(commands, @r###"
+        [
+            "tmux -L [SOCKET_NAME] new-session -d -s foo -n bar -c [TEMP_DIR]/working_dir",
+            "tmux -L [SOCKET_NAME] send-keys -t foo:bar bar Enter",
+        ]
+        "###);
+
+        let expected_file_path = working_dir.join("foo.txt");
+        wait_for_file(
+            expected_file_path.as_path(),
+            format!("file not created: {}", expected_file_path.display()),
+        );
+
+        Ok(())
+    }
+
+    // TODO: validate paths eagerly (and error instead of running & failing)
+    // TODO: support project specific crates that automatically get added to $PATH within the window
+}

--- a/global/src/tmux.rs
+++ b/global/src/tmux.rs
@@ -390,7 +390,7 @@ mod tests {
     };
 
     use anyhow::Result;
-    use insta::{assert_debug_snapshot, assert_yaml_snapshot};
+    use insta::assert_debug_snapshot;
     use rand::{distributions::Alphanumeric, Rng};
     use tempfile::tempdir;
     use test_utils::{create_workspace_with_packages, FakeBin, FakePackage};
@@ -647,13 +647,13 @@ mod tests {
         let commands = startup_tmux(&config, &options)?;
         let commands = sanitize_commands_executed(commands, &options, None);
 
-        assert_yaml_snapshot!(commands, @r###"
-        ---
-        - "tmux -L [SOCKET_NAME] new-session -d -s foo -n bar"
-        - "tmux -L [SOCKET_NAME] new-window -t foo: -n baz"
-        - "tmux -L [SOCKET_NAME] new-window -t foo: -n qux"
-        - "tmux -L [SOCKET_NAME] new-window -t foo: -n derp"
-        - "tmux attach -t foo",
+        assert_debug_snapshot!(commands, @r###"
+        [
+            "tmux -L [SOCKET_NAME] new-session -d -s foo -n bar",
+            "tmux -L [SOCKET_NAME] new-window -t foo: -n baz",
+            "tmux -L [SOCKET_NAME] new-window -t foo: -n qux",
+            "tmux -L [SOCKET_NAME] new-window -t foo: -n derp",
+        ]
         "###);
 
         assert_debug_snapshot!(gather_tmux_state(&options), @r###"
@@ -706,9 +706,10 @@ mod tests {
         let commands = startup_tmux(&config, &options)?;
         let commands = sanitize_commands_executed(commands, &options, None);
 
-        assert_yaml_snapshot!(commands, @r###"
-        ---
-        - "tmux -L [SOCKET_NAME] new-window -t foo: -n bar"
+        assert_debug_snapshot!(commands, @r###"
+        [
+            "tmux -L [SOCKET_NAME] new-window -t foo: -n bar",
+        ]
         "###);
 
         assert_debug_snapshot!(gather_tmux_state(&options), @r###"
@@ -757,10 +758,7 @@ mod tests {
         let commands = startup_tmux(&config, &options)?;
         let commands = sanitize_commands_executed(commands, &options, None);
 
-        assert_yaml_snapshot!(commands, @r###"
-        ---
-        []
-        "###);
+        assert_debug_snapshot!(commands, @"[]");
 
         assert_debug_snapshot!(gather_tmux_state(&options), @r###"
         {
@@ -818,10 +816,11 @@ mod tests {
 
         let commands =
             sanitize_commands_executed(commands, &options, Some(additional_replacements));
-        assert_yaml_snapshot!(commands, @r###"
-        ---
-        - "tmux -L [SOCKET_NAME] new-session -d -s foo -n bar -e BAZ=qux -e FOO=bar"
-        - "tmux -L [SOCKET_NAME] send-keys -t foo:bar 'echo \"$FOO-$BAZ\" > /tmp/random-value/some-file.txt' Enter"
+        assert_debug_snapshot!(commands, @r###"
+        [
+            "tmux -L [SOCKET_NAME] new-session -d -s foo -n bar -e BAZ=qux -e FOO=bar",
+            "tmux -L [SOCKET_NAME] send-keys -t foo:bar 'echo \"$FOO-$BAZ\" > /tmp/random-value/some-file.txt' Enter",
+        ]
         "###);
 
         wait_for_file(
@@ -877,10 +876,11 @@ mod tests {
 
         let commands =
             sanitize_commands_executed(commands, &options, Some(additional_replacements));
-        assert_yaml_snapshot!(commands, @r###"
-        ---
-        - "tmux -L [SOCKET_NAME] new-session -d -s foo -n bar"
-        - "tmux -L [SOCKET_NAME] send-keys -t foo:bar 'touch /tmp/random-value/some-file.txt' Enter"
+        assert_debug_snapshot!(commands, @r###"
+        [
+            "tmux -L [SOCKET_NAME] new-session -d -s foo -n bar",
+            "tmux -L [SOCKET_NAME] send-keys -t foo:bar 'touch /tmp/random-value/some-file.txt' Enter",
+        ]
         "###);
         assert_debug_snapshot!(gather_tmux_state(&options), @r###"
         {

--- a/global/src/tmux.rs
+++ b/global/src/tmux.rs
@@ -1073,6 +1073,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_linked_crates() -> Result<()> {
         let temp_dir = tempdir()?;
         let options = build_testing_options();

--- a/startup_tmux/Cargo.toml
+++ b/startup_tmux/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "startup_tmux"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Robert Jackson <me@rwjblue.com>"]
+
+[dependencies]
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+
+[dev-dependencies]
+insta = { version = "1.36.1"  }
+fixturify = { path = "../fixturify/"}
+tempfile = "3.10.1"

--- a/startup_tmux/src/bin.rs
+++ b/startup_tmux/src/bin.rs
@@ -1,0 +1,79 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use binutils::tmux::{startup_tmux, TmuxOptions};
+use clap::Parser;
+use config::read_config;
+use tracing_subscriber::EnvFilter;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct CliTmuxOptions {
+    /// Enable dry run mode. No commands will be executed.
+    #[arg(long)]
+    dry_run: bool,
+
+    /// Enable debug mode. Provides additional output for debugging.
+    #[arg(long)]
+    debug: bool,
+
+    /// Attach to the tmux session after starting it. Defaults to attaching if not within a
+    /// TMUX session already.
+    #[arg(long)]
+    attach: Option<bool>,
+
+    /// Specify the tmux socket name. Defaults to the main tmux socket.
+    #[arg(long)]
+    socket_name: Option<String>,
+
+    /// Path to the configuration file. Defaults to `~/.config/binutils/config.yaml`.
+    #[arg(long)]
+    config_file: Option<String>,
+}
+
+impl TmuxOptions for CliTmuxOptions {
+    fn is_dry_run(&self) -> bool {
+        self.dry_run
+    }
+
+    fn is_debug(&self) -> bool {
+        self.debug
+    }
+
+    fn should_attach(&self) -> Option<bool> {
+        self.attach
+    }
+
+    fn socket_name(&self) -> Option<String> {
+        self.socket_name.clone()
+    }
+
+    fn config_file(&self) -> Option<PathBuf> {
+        self.config_file.as_ref().map(PathBuf::from)
+    }
+}
+
+fn main() -> Result<()> {
+    // Initialize tracing, but only if RUST_LOG is set
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("off")),
+        )
+        .init();
+
+    latest_bin::ensure_latest_bin()?;
+
+    let options = CliTmuxOptions::parse();
+    let config = read_config(options.config_file())?;
+
+    let commands = startup_tmux(&config, &options)?;
+
+    if options.dry_run {
+        println!("Would run the following commands:");
+        for command in commands {
+            println!("\t{}", command);
+        }
+    }
+
+    Ok(())
+}

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -17,8 +17,8 @@ pub struct TestEnvironment {
 impl Drop for TestEnvironment {
     fn drop(&mut self) {
         match &self.original_home {
-            Some(home) => env::set_var("HOME", home),
-            None => env::remove_var("HOME"),
+            Some(home) => unsafe { env::set_var("HOME", home) },
+            None => unsafe { env::remove_var("HOME") },
         }
     }
 }
@@ -28,12 +28,14 @@ pub fn setup_test_environment() -> TestEnvironment {
     let temp_dir = tempdir().expect("Failed to create temp dir");
     let temp_home = temp_dir.into_path();
 
-    env::set_var(
-        "HOME",
-        temp_home
-            .to_str()
-            .expect("Failed to convert temp path to str"),
-    );
+    unsafe {
+        env::set_var(
+            "HOME",
+            temp_home
+                .to_str()
+                .expect("Failed to convert temp path to str"),
+        );
+    }
 
     // Ensure config directory exists
     let config_dir = temp_home.join(".config/binutils");

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -17,8 +17,8 @@ pub struct TestEnvironment {
 impl Drop for TestEnvironment {
     fn drop(&mut self) {
         match &self.original_home {
-            Some(home) => unsafe { env::set_var("HOME", home) },
-            None => unsafe { env::remove_var("HOME") },
+            Some(home) => env::set_var("HOME", home),
+            None => env::remove_var("HOME"),
         }
     }
 }
@@ -28,14 +28,12 @@ pub fn setup_test_environment() -> TestEnvironment {
     let temp_dir = tempdir().expect("Failed to create temp dir");
     let temp_home = temp_dir.into_path();
 
-    unsafe {
-        env::set_var(
-            "HOME",
-            temp_home
-                .to_str()
-                .expect("Failed to convert temp path to str"),
-        );
-    }
+    env::set_var(
+        "HOME",
+        temp_home
+            .to_str()
+            .expect("Failed to convert temp path to str"),
+    );
 
     // Ensure config directory exists
     let config_dir = temp_home.join(".config/binutils");


### PR DESCRIPTION
Copies most bins from
<https://github.com/rwjblue/dotfiles/tree/master/binutils/crates/global/src/bin> into a new crate, `global`.

The intended use is:

1. `$PATH` contains something like:

  - "$HOME/src/github/hjdivad/dotfiles/local-packages/crates/global/target/debug"
  - "$HOME/src/github/hjdivad/dotfiles/packages/binutils/crates/global/target/debug"
  - "$HOME/src/github/malleatus/shared_binutils/global/target/debug"

2. dotfiles still has its own `rs/generate-binutils-symlinks.rs`

3. `cargo build && ./target/debug/generate-binutils-symlinks` is ran in
   both dotfiles and shared_binutils

`generate-binutils-symlinks` needs duplication because what it inspects
depends on where it is built.

`rebuild_binutils` wasn't copied because it seems pointless if all the
bins already rely on `latest_bin`.
