### PR TITLE
feat: shell crate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,9 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
+
+      - run: sudo apt-get update && sudo apt-get install -y zsh
+
       - run: cargo nextest run --workspace
 
   lint:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["config", "fixturify", "internal-bins", "latest_bin", "test_utils", "global"]
+members = ["config", "fixturify", "internal-bins", "latest_bin", "test_utils", "global", "shell"]
 
 [profile.dev.package]
 insta.opt-level = 3

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "shell"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["David J. Hamilton <david@hamilton.gg>"]
+
+[dependencies]
+anyhow = "1.0.79"
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+
+[dev-dependencies]
+insta = { version = "1.36.1" }
+tempfile = "3.10.1"

--- a/shell/Readme.md
+++ b/shell/Readme.md
@@ -1,0 +1,25 @@
+# Shell Utilities
+
+Example Usage:
+
+```rust
+use shell::*;
+
+fn test_in_dir_and_sh_macros() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+
+    in_dir!(temp_dir.path(), {
+        sh!("touch foo.md bar.md baz.md")?;
+
+        let output = sh!("ls")?;
+
+        println!("{}", output);
+
+        assert!(output.contains("foo.md"));
+        assert!(output.contains("bar.md"));
+        assert!(output.contains("baz.md"));
+
+        Ok(())
+    })?;
+}
+```

--- a/shell/src/lib.rs
+++ b/shell/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod prelude;
+// I don't particularly want to expose these as shell::*;
+// Without this line, it works fine to use shell::prelude::* for cargo, but rust-analyzer complains
+// it can't find the macro.
+pub use prelude::*;

--- a/shell/src/prelude.rs
+++ b/shell/src/prelude.rs
@@ -1,0 +1,111 @@
+use std::{cell::RefCell, path::PathBuf};
+
+thread_local! {
+    pub static CMD_DIR: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
+}
+
+#[macro_export]
+/// Sets the cwd for invocations of sh! within the given block.
+/// Prior cwd is restored when exiting the block.
+///
+/// All uses of sh! share the same thread-local
+macro_rules! in_dir {
+    ($dir:expr, $block:block) => {{
+        use anyhow::Result;
+
+        CMD_DIR.with(|current_dir| {
+            let previous_dir = current_dir.replace(Some(PathBuf::from($dir)));
+            let result = (|| -> Result<_> { $block })();
+            current_dir.replace(previous_dir);
+            result
+        })
+    }};
+}
+
+#[macro_export]
+/// Run the shell command `$cmd` using zsh.
+/// Return `Ok(stdout)` on success.
+/// If the command cannot be invoked, return an error that includes the command string.
+/// If the command exits non-zero, return an error with the comamnd string, stdout and stderr.
+///
+/// Not the least bit optimized for performance.
+macro_rules! sh {
+    ($cmd:expr) => {{
+        use anyhow::Context;
+
+        CMD_DIR.with(|cmd_dir| {
+            use std::process::Command;
+
+            let mut command = Command::new("zsh");
+            command.args(vec!["-c", $cmd]);
+
+            if let Some(cwd) = cmd_dir.borrow().as_ref() {
+                command.current_dir(cwd);
+            }
+
+            let output = command
+                .output()
+                .context(format!("Running command: {:?}", command))?;
+
+            if !output.status.success() {
+                let stdout = String::from_utf8(output.stdout)?.trim().to_string();
+                let stderr = String::from_utf8(output.stderr)?.trim().to_string();
+                return Err(anyhow::anyhow!(format!(
+                    "cmd: {:?}\n\nout:\n\n{}\n\nerr:\n\n{}",
+                    command, stdout, stderr
+                )));
+            }
+            Ok(String::from_utf8(output.stdout)?.trim().to_string())
+        })
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+
+    #[test]
+    fn test_in_dir_and_sh_macros() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+
+        in_dir!(temp_dir.path(), {
+            sh!("touch foo.md bar.md baz.md")?;
+
+            let output = sh!("ls")?;
+
+            println!("{}", output);
+
+            assert!(output.contains("foo.md"));
+            assert!(output.contains("bar.md"));
+            assert!(output.contains("baz.md"));
+
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_stderr_in_errors() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+
+        in_dir!(temp_dir.path(), {
+            sh!("touch foo.md")?;
+
+            let result = sh!("ls foo.md bar.md baz.md");
+
+            assert!(result.is_err());
+
+            if let Err(err) = result {
+                let error_message = format!("{}", err);
+                assert!(error_message.contains("bar.md"));
+                assert!(error_message.contains("baz.md"));
+            }
+
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
```rust
use shell::*;

fn test_in_dir_and_sh_macros() -> Result<()> {
    let temp_dir = tempfile::tempdir()?;

    in_dir!(temp_dir.path(), {
        sh!("touch foo.md bar.md baz.md")?;

        let output = sh!("ls")?;

        println!("{}", output);

        assert!(output.contains("foo.md"));
        assert!(output.contains("bar.md"));
        assert!(output.contains("baz.md"));

        Ok(())
    })?;
}
```
