### PR TITLE
feat(tmux): ensure windows are created at specific indexes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,8 @@ jobs:
       - name: Write basic .tmux.conf
         run: echo 'set -g base-index 1' > ~/.tmux.conf
 
+      - run: tmux -V
+
       - run: cargo nextest run --workspace
 
   lint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,10 @@ jobs:
         run: echo 'set -g base-index 1' > ~/.tmux.conf
 
       - run: tmux -V
+      - run: |
+          tmux new-session -d -s temp_session
+          tmux show-options -g
+          tmux kill-session -t temp_session
 
       - run: cargo nextest run --workspace
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,9 @@ jobs:
 
       - run: sudo apt-get update && sudo apt-get install -y zsh
 
+      - name: Write basic .tmux.conf
+        run: echo 'set -g base-index 1' > ~/.tmux.conf
+
       - run: cargo nextest run --workspace
 
   lint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   test:
+    env:
+      RUST_LOG: trace
+
     name: cargo test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,10 +29,6 @@ jobs:
         run: echo 'set -g base-index 1' > ~/.tmux.conf
 
       - run: tmux -V
-      - run: |
-          tmux new-session -d -s temp_session
-          tmux show-options -g
-          tmux kill-session -t temp_session
 
       - run: cargo nextest run --workspace
 

--- a/global/src/tmux/mod.rs
+++ b/global/src/tmux/mod.rs
@@ -971,7 +971,9 @@ mod tests {
 
     #[test]
     fn test_attempts_to_attach_to_default_session() -> Result<()> {
-        env::remove_var("TMUX");
+        unsafe {
+            env::remove_var("TMUX");
+        }
 
         let options = build_testing_options();
 
@@ -1007,7 +1009,9 @@ mod tests {
 
     #[test]
     fn test_attempts_to_attach_without_default_session() -> Result<()> {
-        env::remove_var("TMUX");
+        unsafe {
+            env::remove_var("TMUX");
+        }
 
         let options = build_testing_options();
 

--- a/global/src/tmux/mod.rs
+++ b/global/src/tmux/mod.rs
@@ -395,6 +395,7 @@ mod tests {
     use rand::{distributions::Alphanumeric, Rng};
     use tempfile::tempdir;
     use test_utils::{create_workspace_with_packages, FakeBin, FakePackage};
+    use tracing_subscriber::EnvFilter;
 
     use crate::build_utils::generate_symlinks;
 
@@ -498,6 +499,14 @@ mod tests {
             .unwrap_or(false)
     }
 
+    fn setup_tracing() {
+        tracing_subscriber::fmt()
+            .with_env_filter(
+                EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("off")),
+            )
+            .init();
+    }
+
     fn build_testing_options() -> TestingTmuxOptions {
         // Make tests stable regardless of if we are within a TMUX session or not
         unsafe { env::remove_var("TMUX") }
@@ -514,6 +523,8 @@ mod tests {
             !tmux_server_running(&options),
             "precond - tmux server should not be running on randomized socket name"
         );
+
+        setup_tracing();
 
         options
     }

--- a/global/src/tmux/mod.rs
+++ b/global/src/tmux/mod.rs
@@ -168,7 +168,7 @@ fn compare_presumed_vs_actual_state(current_state: &mut TmuxState, options: &imp
 
             if options._is_testing() {
                 // NOTE: make the tests fail if our expected internal representation doesn't match reality
-                // panic!("{}", message);
+                panic!("{}", message);
             }
         }
     }

--- a/global/src/tmux/mod.rs
+++ b/global/src/tmux/mod.rs
@@ -222,7 +222,7 @@ fn compare_presumed_vs_actual_state(current_state: &mut TmuxState, options: &imp
 
             if options._is_testing() {
                 // NOTE: make the tests fail if our expected internal representation doesn't match reality
-                panic!("{}", message);
+                // panic!("{}", message);
             }
         }
     }

--- a/global/src/tmux/mod.rs
+++ b/global/src/tmux/mod.rs
@@ -90,9 +90,9 @@ pub fn startup_tmux(config: &Config, options: &impl TmuxOptions) -> Result<Vec<S
             // when the tmux server is not started at all, we can't call determine_base_index yet
             // this feels silly, there probably is a better way to do it
             let mut base_index: Option<usize> = if current_state.is_empty() {
-                Some(determine_base_index()?)
-            } else {
                 None
+            } else {
+                Some(determine_base_index()?)
             };
 
             for session in &tmux.sessions {

--- a/global/src/tmux/mod.rs
+++ b/global/src/tmux/mod.rs
@@ -62,18 +62,20 @@ fn determine_base_index() -> Result<usize> {
         .context("Failed to determine `base-index` for tmux")?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    if output.status.success() {
-        trace!(
-            "Retrieving `base-index` from `tmux show-option -g base-index` output: {}",
-            stdout
-        );
 
+    trace!(
+        "Retrieving `base-index` from `tmux show-option -g base-index` output: {:?}",
+        output
+    );
+
+    if output.status.success() {
         if let Some(index_str) = stdout.split_whitespace().nth(1) {
             if let Ok(index) = usize::from_str(index_str) {
                 return Ok(index);
             }
         }
     }
+
     trace!("Failed to parse `base-index` from tmux output: {}", stdout);
 
     Ok(0) // Default value


### PR DESCRIPTION
Refactored `startup-tmux` to ensure windows are re-created at the correct indexes within the session.

For the ordering to work properly, you must have ran `set -g base-index 1` in your `~/.tmux.conf`.
