### PR TITLE
feat(fetch): add URL fetching capability to cache-shell-startup

### DIFF
--- a/global/Cargo.toml
+++ b/global/Cargo.toml
@@ -17,6 +17,7 @@ config = { path = "../config" }
 latest_bin = { path = "../latest_bin" }
 regex = "1.10.6"
 shellexpand = "3.1.0"
+ureq = "2.10.1"
 
 [dev-dependencies]
 insta = { version = "1.36.1", features = ["yaml", "toml"] }
@@ -25,3 +26,4 @@ temp-env = "0.3.6"
 rand = "0.8.5"
 test_utils = { path = "../test_utils" }
 fixturify = { path = "../fixturify" }
+mockito = "1.5.0"


### PR DESCRIPTION
- Added ureq dependency to global/Cargo.toml for making HTTP requests.
- Added mockito dependency to global/Cargo.toml for testing HTTP requests.
- Enhanced process_file function to fetch content from URLs specified with `# FETCH: `prefix.
- Introduced a new test to verify the URL fetching functionality using mockito.

Note: I had an error when running `cargo nextest` after installing `mockito`, I needed to upgrade my version of `cargo-nextest` (was some sort of bug in one of the deps they use to determine test packaging?)

Fixes #26
