### PR TITLE
feat(handlebars): integrate Handlebars template engine

### DIFF
--- a/global/Cargo.toml
+++ b/global/Cargo.toml
@@ -18,6 +18,7 @@ latest_bin = { path = "../latest_bin" }
 regex = "1.10.6"
 shellexpand = "3.1.0"
 ureq = "2.10.1"
+handlebars = "6.1.0"
 
 [dev-dependencies]
 insta = { version = "1.36.1", features = ["yaml", "toml"] }

--- a/global/src/tmux/mod.rs
+++ b/global/src/tmux/mod.rs
@@ -436,8 +436,7 @@ mod tests {
     use insta::assert_debug_snapshot;
     use rand::{distributions::Alphanumeric, Rng};
     use tempfile::tempdir;
-    use test_utils::{create_workspace_with_packages, FakeBin, FakePackage};
-    use tracing_subscriber::EnvFilter;
+    use test_utils::{create_workspace_with_packages, setup_tracing, FakeBin, FakePackage};
 
     use crate::build_utils::generate_symlinks;
 
@@ -539,14 +538,6 @@ mod tests {
             .status()
             .map(|status| status.success())
             .unwrap_or(false)
-    }
-
-    fn setup_tracing() {
-        tracing_subscriber::fmt()
-            .with_env_filter(
-                EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("off")),
-            )
-            .init();
     }
 
     fn build_testing_options() -> TestingTmuxOptions {

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2021"
 
 [dependencies]
 tempfile = "3.10.1"
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -3,6 +3,7 @@ use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use tracing_subscriber::EnvFilter;
 
 use tempfile::tempdir;
 
@@ -24,6 +25,8 @@ impl Drop for TestEnvironment {
 }
 
 pub fn setup_test_environment() -> TestEnvironment {
+    setup_tracing();
+
     let original_home = env::var("HOME").ok();
     let temp_dir = tempdir().expect("Failed to create temp dir");
     let temp_home = temp_dir.into_path();
@@ -127,6 +130,15 @@ pub fn create_workspace_with_packages(workspace_dir: &Path, packages: Vec<FakePa
             String::from_utf8_lossy(&output.stderr)
         );
     }
+}
+
+pub fn setup_tracing() {
+    // TODO: figure out if there is already a formatter setup, and noop
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("off")),
+        )
+        .init();
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Added `handlebars` dependency in `Cargo.toml`.
- Implemented `inline_command` and `inline_remote_content` helpers.
- Refactored `process_file` and related functions to use Handlebars template rendering.
- Moved `setup_tracing` function to `test_utils`.

This integration allows more flexible and powerful file processing using Handlebars templates.

---

Example usage:

```handlebars
# .zshrc
{{inline_remote_content "https://some-url.com/goes-here"}}

{{inline_command "echo 'Hello, World!'"}}
```
