### PR TITLE
Expose `setup_tracing` test helper.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,6 +1444,7 @@ name = "test_utils"
 version = "0.1.0"
 dependencies = [
  "tempfile",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/global/src/tmux/mod.rs
+++ b/global/src/tmux/mod.rs
@@ -436,8 +436,7 @@ mod tests {
     use insta::assert_debug_snapshot;
     use rand::{distributions::Alphanumeric, Rng};
     use tempfile::tempdir;
-    use test_utils::{create_workspace_with_packages, FakeBin, FakePackage};
-    use tracing_subscriber::EnvFilter;
+    use test_utils::{create_workspace_with_packages, setup_tracing, FakeBin, FakePackage};
 
     use crate::build_utils::generate_symlinks;
 
@@ -451,6 +450,7 @@ mod tests {
         socket_name: String,
         _config_file: Option<PathBuf>,
     }
+
     impl TmuxOptions for TestingTmuxOptions {
         fn is_dry_run(&self) -> bool {
             self.dry_run
@@ -539,14 +539,6 @@ mod tests {
             .status()
             .map(|status| status.success())
             .unwrap_or(false)
-    }
-
-    fn setup_tracing() {
-        tracing_subscriber::fmt()
-            .with_env_filter(
-                EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("off")),
-            )
-            .init();
     }
 
     fn build_testing_options() -> TestingTmuxOptions {

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -12,3 +12,4 @@ workspace = true
 
 [dependencies]
 tempfile = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -3,6 +3,7 @@ use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use tracing_subscriber::EnvFilter;
 
 use tempfile::tempdir;
 
@@ -23,7 +24,17 @@ impl Drop for TestEnvironment {
     }
 }
 
+pub fn setup_tracing() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("off")),
+        )
+        .init();
+}
+
 pub fn setup_test_environment() -> TestEnvironment {
+    setup_tracing();
+
     let original_home = env::var("HOME").ok();
     let temp_dir = tempdir().expect("Failed to create temp dir");
     let temp_home = temp_dir.into_path();


### PR DESCRIPTION
This can be used in tests to get better debugging output when you have a
test failure.
