### PR TITLE
feat: Add support for linked crates

### DIFF
--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -108,6 +108,11 @@ pub fn create_workspace_with_packages(workspace_dir: &Path, packages: Vec<FakePa
         )
         .unwrap();
 
+        // Write an empty `src/lib.rs` (makes crates without bins valid)
+        let src_dir = package_dir.join("src");
+        fs::create_dir_all(&src_dir).unwrap();
+        fs::write(src_dir.join("lib.rs"), "").unwrap();
+
         // Create src/bin directory and bin files
         let src_bin_dir = package_dir.join("src/bin");
         fs::create_dir_all(&src_bin_dir).unwrap();


### PR DESCRIPTION
Example config:

```lua
---@type Config
return {
  crate_locations = {
    "~/src/rwjblue/dotfiles/binutils/crates/",
    "~/src/malleatus/shared_binutils"
  },
  tmux = {
    sessions = {
      {
        name = "some session",
        windows = {
          {
            name = "test window",
            path = "~/src/malleatus/shared_binutils",
            linked_crates = {
              "internal-bins"
            },
            command = "nvim"
          }
        }
      },
    }
  }
}

```