### PR TITLE
ci: Ensure all tests run in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - run: tmux -V
 
-      - run: cargo nextest run --workspace
+      - run: cargo nextest run --workspace --no-fail-fast
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Without the `--no-fail-fast` option `cargo nextest run` will stop
running tests as soon as it hits the first failure. That's a great
feature, but out whole test suite doesn't take too long and it's much
better to see all of the failures in CI rather than just the first one.
