### PR TITLE
feat(regenerate-config-types): accept `--input` and `--output`

### DIFF
--- a/.github/workflows/update-config.yaml
+++ b/.github/workflows/update-config.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - run: cargo run --bin regenerate-config-types
+      - run: cargo run --bin regenerate-config-types --input config/src/lib.rs --output config/init.lua
 
       - name: Commit and push changes
         run: |

--- a/internal-bins/src/bin/regenerate-config-types.rs
+++ b/internal-bins/src/bin/regenerate-config-types.rs
@@ -4,23 +4,17 @@ use std::path::PathBuf;
 use anyhow::Result;
 use tracing_subscriber::EnvFilter;
 
+/// Generate lua types for a given file's desearializable structs
 #[derive(Parser, Debug)]
-#[command(name = "Regenerate config's Lua types")]
+#[command()]
 struct Args {
-    /// Sets the output file path. Defaults to `config_schema.json` in the crate root.
+    /// Sets the input file (the rust file that contains the structs)
     #[arg(short, long, value_name = "FILE")]
-    output: Option<String>,
-}
+    input: PathBuf,
 
-fn generate_lua_types() -> Result<()> {
-    let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-
-    internal_bins::lua::process_file(
-        crate_root.join("../config/src/lib.rs"),
-        crate_root.join("../config/init.lua"),
-    );
-
-    Ok(())
+    /// Sets the output file path (where the `.lua` type output should go)
+    #[arg(short, long, value_name = "FILE")]
+    output: PathBuf,
 }
 
 fn main() -> Result<()> {
@@ -33,7 +27,9 @@ fn main() -> Result<()> {
 
     latest_bin::ensure_latest_bin()?;
 
-    generate_lua_types()?;
+    let args = Args::parse();
+
+    internal_bins::lua::process_file(args.input, args.output);
 
     Ok(())
 }


### PR DESCRIPTION
Part of #47
