### PR TITLE
Update mlua to 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,15 +884,17 @@ dependencies = [
 
 [[package]]
 name = "mlua"
-version = "0.9.9"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d111deb18a9c9bd33e1541309f4742523bfab01d276bfa9a27519f6de9c11dc7"
+checksum = "0ae9546e4a268c309804e8bbb7526e31cbfdedca7cd60ac1b987d0b212e0d876"
 dependencies = [
+ "anyhow",
  "bstr",
+ "either",
  "erased-serde",
  "mlua-sys",
  "num-traits",
- "once_cell",
+ "parking_lot",
  "rustc-hash",
  "serde",
  "serde-value",
@@ -900,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "mlua-sys"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe026d6bd1583a9cf9080e189030ddaea7e6f5f0deb366a8e26f8a26c4135b8"
+checksum = "efa6bf1a64f06848749b7e7727417f4ec2121599e2a10ef0a8a3888b0e9a5a0d"
 dependencies = [
  "cc",
  "cfg-if",
@@ -1802,7 +1804,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,12 @@ fixturify = { path = "fixturify" }
 lua_config_utils = { path = "lua_config_utils" }
 cargo_metadata = "0.18.1"
 ignore = "0.4.23"
-mlua = { version = "0.9.9", features = ["lua54", "vendored", "serialize"] }
+mlua = { version = "0.10.1", features = [
+  "lua54",
+  "vendored",
+  "serialize",
+  "anyhow",
+] }
 regex = "1.11.1"
 schemars = "0.8.21"
 serde = { version = "1.0.214", features = ["derive"] }


### PR DESCRIPTION
Mostly a drop in upgrade, but some changes required adding `anyhow` feature (or using `error-send`) to make the `mlua::Error` compatible with `anyhow::Error`.
