### PR TITLE
feat: Make local-dotfiles nvim config setup mirror LazyVim

### DIFF
--- a/global/src/bin/setup-local-dotfiles.rs
+++ b/global/src/bin/setup-local-dotfiles.rs
@@ -43,7 +43,10 @@ fn ensure_directory_structure(base_path: &Path, dry_run: bool) -> Result<()> {
 
     let paths = [
         "crates/.gitkeep",
-        "nvim/config/lua/local_config/.gitkeep",
+        "nvim/config/lua/local_config/config/autocmds.lua",
+        "nvim/config/lua/local_config/config/options.lua",
+        "nvim/config/lua/local_config/config/keymaps.lua",
+        "nvim/config/lua/local_config/plugins/.gitkeep",
         "nvim/config/snippets/.gitkeep",
     ];
 
@@ -390,9 +393,6 @@ mod tests {
         assert!(base_path.exists());
         assert!(base_path.join(".git").exists());
         assert!(base_path.join("crates/.gitkeep").exists());
-        assert!(base_path
-            .join("nvim/config/lua/local_config/.gitkeep")
-            .exists());
         assert!(base_path.join("nvim/config/snippets/.gitkeep").exists());
 
         assert!(local_crates_path.exists());
@@ -414,7 +414,10 @@ mod tests {
         assert_debug_snapshot!(result, @r###"
         {
             "crates/.gitkeep": "",
-            "nvim/config/lua/local_config/.gitkeep": "",
+            "nvim/config/lua/local_config/config/autocmds.lua": "",
+            "nvim/config/lua/local_config/config/keymaps.lua": "",
+            "nvim/config/lua/local_config/config/options.lua": "",
+            "nvim/config/lua/local_config/plugins/.gitkeep": "",
             "nvim/config/snippets/.gitkeep": "",
         }
         "###);
@@ -518,6 +521,10 @@ mod tests {
         {
             "crates/.gitkeep": "",
             "nvim/config/lua/local_config/.gitkeep": "",
+            "nvim/config/lua/local_config/config/autocmds.lua": "",
+            "nvim/config/lua/local_config/config/keymaps.lua": "",
+            "nvim/config/lua/local_config/config/options.lua": "",
+            "nvim/config/lua/local_config/plugins/.gitkeep": "",
             "nvim/config/snippets/.gitkeep": "",
         }
         "###);
@@ -540,7 +547,10 @@ mod tests {
         assert_debug_snapshot!(result, @r###"
         {
             "crates/.gitkeep": "",
-            "nvim/config/lua/local_config/.gitkeep": "",
+            "nvim/config/lua/local_config/config/autocmds.lua": "",
+            "nvim/config/lua/local_config/config/keymaps.lua": "",
+            "nvim/config/lua/local_config/config/options.lua": "",
+            "nvim/config/lua/local_config/plugins/.gitkeep": "",
             "nvim/config/snippets/.gitkeep": "",
         }
         "###);
@@ -572,8 +582,11 @@ mod tests {
         {
             "crates/.gitkeep": "",
             "crates/existing-crate/Cargo.toml": "[package]",
-            "nvim/config/lua/local_config/.gitkeep": "",
+            "nvim/config/lua/local_config/config/autocmds.lua": "",
+            "nvim/config/lua/local_config/config/keymaps.lua": "",
+            "nvim/config/lua/local_config/config/options.lua": "",
             "nvim/config/lua/local_config/init.lua": "-- Config",
+            "nvim/config/lua/local_config/plugins/.gitkeep": "",
             "nvim/config/snippets/.gitkeep": "",
         }
         "###);


### PR DESCRIPTION
This updates the `setup-local-dotfiles` cli to bootstrap a bit more of the LazyVim folder structure. This allows you to add things like:

```lua
-- from config/options.lua

require('local_config/config/options')
```

I prefer this to using `pcall` since pcall will swallow any errors (and is annoying to debug).

---

Also, RE: plugins,  you can add this to your `lua/config/lazy.lua`:

```lua
require("lazy").setup({
  spec = {
    -- add LazyVim and import its plugins
    { "LazyVim/LazyVim", import = "lazyvim.plugins" },
    { import = "plugins" },
    { import = "local_config.plugins" }
  }
})
```