### PR TITLE
feat(config): add config validation

### DIFF
--- a/global/src/bin/startup-tmux.rs
+++ b/global/src/bin/startup-tmux.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use clap::Parser;
 use config::read_config;
 use global::tmux::{startup_tmux, TmuxOptions};
+use tracing::debug;
 use tracing_subscriber::EnvFilter;
 
 #[derive(Parser, Debug)]
@@ -65,6 +66,7 @@ fn main() -> Result<()> {
 
     let options = CliTmuxOptions::parse();
     let config = read_config(options.config_file())?;
+    debug!("Using config: \n{:#?}", config);
 
     let commands = startup_tmux(&config, &options)?;
 

--- a/global/src/tmux/mod.rs
+++ b/global/src/tmux/mod.rs
@@ -231,6 +231,12 @@ fn ensure_window(
             commands_executed.push(run_command(cmd, options)?);
             commands_executed.extend(execute_command(session_name, window, crates, options)?);
 
+            trace!(
+                "Attempting to insert window '{}' at index {} into vector of length {}",
+                window.name,
+                *window_index,
+                windows.len()
+            );
             windows.insert(*window_index, window.name.to_string());
         }
     } else {


### PR DESCRIPTION
I ran into an issue where I accidentally had duplicate window names within a single session (I had copied one to make another window but forgot to change the name). This resulted in a really annoying panic.

After these changes you'd get an actually "pretty good" error message:

```
Error: Configuration validation failed
Config file: /Users/rjackson/.config/binutils/local.config.lua

Issues found:
- Duplicate window name 'dotvim' found in session 'dotfiles' at indices 0 and 1
```

This also allows us to start adding more checks / validations for other config values in the future. For example:

- Verify that the various paths included in the config are valid paths
- Check that all linked crates can be identified (maybe this only needs to happen within startup-tmux?)