### PR TITLE
refactor!(global): Rename `global` crate to `shared_global`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,32 +510,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
-name = "global"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "cargo_metadata",
- "clap",
- "config",
- "fixturify",
- "insta",
- "latest_bin",
- "mockito",
- "pretty_assertions",
- "rand",
- "regex",
- "shellexpand",
- "temp-env",
- "tempfile",
- "test_utils",
- "toml 0.8.20",
- "tracing",
- "tracing-subscriber",
- "ureq",
- "walkdir",
-]
-
-[[package]]
 name = "globset"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,6 +1385,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shared_global"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "clap",
+ "config",
+ "fixturify",
+ "insta",
+ "latest_bin",
+ "mockito",
+ "pretty_assertions",
+ "rand",
+ "regex",
+ "shellexpand",
+ "temp-env",
+ "tempfile",
+ "test_utils",
+ "toml 0.8.20",
+ "tracing",
+ "tracing-subscriber",
+ "ureq",
+ "walkdir",
 ]
 
 [[package]]

--- a/global/Cargo.toml
+++ b/global/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "global"
+name = "shared_global"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/global/src/bin/generate-binutils-symlinks.rs
+++ b/global/src/bin/generate-binutils-symlinks.rs
@@ -44,7 +44,7 @@ fn run(args: Vec<String>, config: &Config) -> Result<()> {
             );
             continue;
         }
-        global::build_utils::generate_symlinks(Some(workspace_path))?;
+        shared_global::build_utils::generate_symlinks(Some(workspace_path))?;
     }
 
     Ok(())

--- a/global/src/bin/startup-tmux.rs
+++ b/global/src/bin/startup-tmux.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use clap::Parser;
 use config::read_config;
-use global::tmux::{startup_tmux, TmuxOptions};
+use shared_global::tmux::{startup_tmux, TmuxOptions};
 use tracing::debug;
 use tracing_subscriber::EnvFilter;
 


### PR DESCRIPTION
I left the folder named `global` still (since it's in a "shared_binutils" repo), but I can rename that too if we prefer.